### PR TITLE
fix: github/resume 링크가 없는 경우 보이지 않도록 수정

### DIFF
--- a/src/components/Header/MainPageHeader.tsx
+++ b/src/components/Header/MainPageHeader.tsx
@@ -66,7 +66,7 @@ const MainPageHeader = ({ className }: MainPageHeaderProps) => {
           </div>
 
           <div className="flex gap-4 w-full items-center justify-end">
-            {"github" in USER_INFORMATIONS && typeof USER_INFORMATIONS["github"] === "string" && (
+            {"github" in USER_INFORMATIONS && !!USER_INFORMATIONS["github"] && (
               <a
                 href={USER_INFORMATIONS["github"]}
                 target="_blank"
@@ -79,7 +79,7 @@ const MainPageHeader = ({ className }: MainPageHeaderProps) => {
               </a>
             )}
 
-            {"resume" in USER_INFORMATIONS && typeof USER_INFORMATIONS["resume"] === "string" && (
+            {"resume" in USER_INFORMATIONS && !!USER_INFORMATIONS["resume"] && (
               <a
                 href={USER_INFORMATIONS["resume"]}
                 target="_blank"

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -27,7 +27,7 @@ const Sidebar = () => {
       </div>
       <div className="flex flex-col gap-4">
         <div className="flex justify-center items-center gap-8">
-          {"github" in USER_INFORMATIONS && typeof USER_INFORMATIONS["github"] === "string" && (
+          {"github" in USER_INFORMATIONS && !!USER_INFORMATIONS["github"] && (
             <a
               href={USER_INFORMATIONS["github"]}
               target="_blank"
@@ -40,7 +40,7 @@ const Sidebar = () => {
             </a>
           )}
 
-          {"resume" in USER_INFORMATIONS && typeof USER_INFORMATIONS["resume"] === "string" && (
+          {"resume" in USER_INFORMATIONS && !!USER_INFORMATIONS["resume"] && (
             <a
               href={USER_INFORMATIONS["resume"]}
               target="_blank"


### PR DESCRIPTION
### 관련 이슈
close #1

### 작업 내용
Sidebar, MainPageHeader 컴포넌트에서 링크가 보이는 조건을 수정했습니다.